### PR TITLE
StaticSite Cleanup while making CloudFront optional for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.6] - 2019-12-28
+### Fixed
+- Correct detection of Serverless Framework projects with a JS config file
+
 ## [1.3.5] - 2019-12-19
 ### Fixed
 - Updated `sls-py` sample to work properly w/ python plugin static caching
@@ -646,7 +650,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Fix changed CFN parameters not being displayed during `runway plan`.
 
-[Unreleased]: https://github.com/onicagroup/runway/compare/v1.3.5...HEAD
+[Unreleased]: https://github.com/onicagroup/runway/compare/v1.3.6...HEAD
+[1.3.6]: https://github.com/onicagroup/runway/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/onicagroup/runway/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/onicagroup/runway/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/onicagroup/runway/compare/v1.3.2...v1.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- pinned `pyhcl` to `<0.3.14`
+    - `0.3.14` vendored ply instead of having it as a dependency which breaks our embedded, patched copy
 
 ## [1.3.6] - 2019-12-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
 
+## [1.3.7] - 2020-01-07
+### Fixed
 - pinned `pyhcl` to `<0.3.14`
     - `0.3.14` vendored ply instead of having it as a dependency which breaks our embedded, patched copy
 
@@ -654,7 +655,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Fix changed CFN parameters not being displayed during `runway plan`.
 
-[Unreleased]: https://github.com/onicagroup/runway/compare/v1.3.6...HEAD
+[Unreleased]: https://github.com/onicagroup/runway/compare/v1.3.7...HEAD
+[1.3.7]: https://github.com/onicagroup/runway/compare/v1.3.6...v1.3.7
 [1.3.6]: https://github.com/onicagroup/runway/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/onicagroup/runway/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/onicagroup/runway/compare/v1.3.3...v1.3.4

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ awacs = "*"
 awscli = ">=1.16.191<2.0"
 docopt = "*"
 future = "*"
-pyhcl = "*"
+pyhcl = "<0.3.14"
 typing = {version = "~= 3.7",markers = "python_version < '3.5'"}
 yamllint = "*"
 zgitignore = "*"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use one of the endpoints below to download a single-binary executable version of
 |------------------|--------------------------------------|
 | Linux            | https://oni.ca/runway/latest/linux   |
 | macOS            | https://oni.ca/runway/latest/osx     |
-| Windows          | https://oni.ca/runway/latest/win     |
+| Windows          | https://oni.ca/runway/latest/windows |
 
 ```shell
 $ curl -L oni.ca/runway/latest/osx -o runway

--- a/README.rst
+++ b/README.rst
@@ -66,15 +66,15 @@ HTTPS Download (e.g cURL)
 Use one of the endpoints below to download a single-binary executable
 version of Runway based on your operating system.
 
-+------------------+------------------------------------+
-| Operating System | Endpoint                           |
-+==================+====================================+
-| Linux            | https://oni.ca/runway/latest/linux |
-+------------------+------------------------------------+
-| macOS            | https://oni.ca/runway/latest/osx   |
-+------------------+------------------------------------+
-| Windows          | https://oni.ca/runway/latest/win   |
-+------------------+------------------------------------+
++------------------+--------------------------------------+
+| Operating System | Endpoint                             |
++==================+======================================+
+| Linux            | https://oni.ca/runway/latest/linux   |
++------------------+--------------------------------------+
+| macOS            | https://oni.ca/runway/latest/osx     |
++------------------+--------------------------------------+
+| Windows          | https://oni.ca/runway/latest/windows |
++------------------+--------------------------------------+
 
 ::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,7 +23,7 @@ on your operating system.
 +------------------+---------------------------------------------------+
 | macOS            | https://oni.ca/runway/latest/osx                  |
 +------------------+---------------------------------------------------+
-| Windows          | https://oni.ca/runway/latest/win                  |
+| Windows          | https://oni.ca/runway/latest/windows              |
 +------------------+---------------------------------------------------+
 
 .. code-block:: shell

--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -38,11 +38,15 @@ be displayed on stack creation/updates.
 A start-to-finish example walkthrough is available
 in the :ref:`Conduit quickstart<qs-conduit>`.
 
-Please note that the CloudFront distribution will take a significant amount
-of time to spin up on initial deploy (10 to 25 minutes is not abnormal). Incorporating
-CloudFront with a static site is a common best practice, however, if
-you are working on a development project it may benefit you to add the
-`staticsite_cf_disable` environment parameter to `true`.
+**Please note:** The CloudFront distribution will take a significant amount
+of time to spin up on initial deploy (10 to 25 minutes is not abnormal).
+Incorporating CloudFront with a static site is a common best practice, however,
+if you are working on a development project it may benefit you to add the
+`staticsite_cf_disable` environment parameter to `true`. To ensure visibility of
+the files that are uploaded, the bucket's policy will be set to a PublicRead
+canned ACL https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.
+This means that every file uploaded will be **publically viewable**. Make sure
+to utilize best practices when uploading sensitive information.
 
 
 .. _staticsite-config-options:

--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -39,7 +39,8 @@ A start-to-finish example walkthrough is available
 in the :ref:`Conduit quickstart<qs-conduit>`.
 
 Please note that the CloudFront distribution will take a significant amount
-of time to spin up on initial deploy (10 to 25 minutes is not abnormal). If
+of time to spin up on initial deploy (10 to 25 minutes is not abnormal). Incorporating
+CloudFront with a static site is a common best practice, however, if
 you are working on a development project it may benefit you to add the
 `staticsite_cf_disable` environment parameter to `true`.
 

--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -4,8 +4,8 @@ Static Site
 ===========
 
 This module type performs idempotent deployments of static websites. It
-combines CloudFormation stacks (for S3 buckets & CloudFront Distribution) with
-additional logic to build & sync the sites.
+combines CloudFormation stacks (for S3 buckets & CloudFront Distribution)
+with additional logic to build & sync the sites.
 
 It can be used with a configuration like the following::
 
@@ -37,6 +37,11 @@ be displayed on stack creation/updates.
 
 A start-to-finish example walkthrough is available
 in the :ref:`Conduit quickstart<qs-conduit>`.
+
+Please note that the CloudFront distribution will take a significant amount
+of time to spin up on initial deploy (10 to 25 minutes is not abnormal). If
+you are working on a development project it may benefit you to add the
+`staticsite_cf_disable` environment parameter to `true`.
 
 
 .. _staticsite-config-options:
@@ -82,6 +87,9 @@ Most of these options are not required, but are listed here for reference::
                   - ErrorCode: 404
                     ResponseCode: 200
                     ResponsePagePath: /index.html
+
+                # Exclude the CloudFront distribution from overall deployment
+                statisite_cf_disable: true
             options:
               pre_build_steps:  # commands to run before generating hash of files
                 - command: npm ci

--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -39,15 +39,10 @@ A start-to-finish example walkthrough is available
 in the :ref:`Conduit quickstart<qs-conduit>`.
 
 **Please note:** The CloudFront distribution will take a significant amount
-of time to spin up on initial deploy (10 to 25 minutes is not abnormal).
+of time to spin up on initial deploy (10 to 60 minutes is not abnormal).
 Incorporating CloudFront with a static site is a common best practice, however,
 if you are working on a development project it may benefit you to add the
-`staticsite_cf_disable` environment parameter to `true`. To ensure visibility of
-the files that are uploaded, the bucket's policy will be set to a PublicRead
-canned ACL https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.
-This means that every file uploaded will be **publically viewable**. Make sure
-to utilize best practices when uploading sensitive information.
-
+`staticsite_cf_disable` environment parameter set to `true`.
 
 .. _staticsite-config-options:
 
@@ -93,7 +88,8 @@ Most of these options are not required, but are listed here for reference::
                     ResponseCode: 200
                     ResponsePagePath: /index.html
 
-                # Exclude the CloudFront distribution from overall deployment
+                # Don't use CloudFront with the site
+                # i.e. for a development site accessible only via its S3-url
                 statisite_cf_disable: true
             options:
               pre_build_steps:  # commands to run before generating hash of files

--- a/docs/source/quickstart/cloudformation.rst
+++ b/docs/source/quickstart/cloudformation.rst
@@ -23,21 +23,21 @@ CloudFormation Quickstart
 
    .. code-block:: shell
 
-       $ curl -L https://oni.ca/latest/osx/runway -o runway
+       $ curl -L https://oni.ca/runway/latest/osx -o runway
        $ chmod +x runway
 
    .. rubric:: Ubuntu
 
    .. code-block:: shell
 
-       $ curl -L https://oni.ca/latest/ubnt/runway -o runway
+       $ curl -L https://oni.ca/runway/latest/linux -o runway
        $ chmod +x runway
 
    .. rubric:: Windows
 
    .. code-block:: shell
 
-       $ curl -L https://oni.ca/latest/win/runway -o runway
+       > iwr -Uri oni.ca/runway/latest/windows -OutFile runway.exe
 
 #. Use Runway to :ref:`generate a sample<command-gen-sample>` `CloudFormation`_
    :ref:`module<runway-module>`, edit the values in the environment file, and

--- a/docs/source/quickstart/conduit.rst
+++ b/docs/source/quickstart/conduit.rst
@@ -45,21 +45,21 @@ Setup
 
    .. code-block:: shell
 
-       curl -L https://oni.ca/latest/osx/runway -o runway
+       curl -L https://oni.ca/runway/latest/osx -o runway
        chmod +x runway
 
    .. rubric:: Ubuntu
 
    .. code-block:: shell
 
-       curl -L https://oni.ca/latest/ubnt/runway -o runway
+       curl -L https://oni.ca/runway/latest/linux -o runway
        chmod +x runway
 
    .. rubric:: Windows
 
    .. code-block:: shell
 
-       curl -L https://oni.ca/latest/win/runway -o runway
+       iwr -Uri oni.ca/runway/latest/windows -OutFile runway.exe
 
 #. Download the source files.
 

--- a/integration_tests/test_serverless/templates/promotezip-multisrc-multizip.sls/serverless.yml
+++ b/integration_tests/test_serverless/templates/promotezip-multisrc-multizip.sls/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-test-pzmsmz
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 package:
   individually: true

--- a/integration_tests/test_serverless/templates/promotezip-multisrc-single-zip.sls/serverless.yml
+++ b/integration_tests/test_serverless/templates/promotezip-multisrc-single-zip.sls/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-test-pzmssz
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   helloWorld:

--- a/integration_tests/test_serverless/templates/promotezip-singlesrc-singlezip.sls/serverless.yml
+++ b/integration_tests/test_serverless/templates/promotezip-singlesrc-singlezip.sls/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-test-sssz
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   helloWorld:

--- a/integration_tests/test_staticsite/__init__.py
+++ b/integration_tests/test_staticsite/__init__.py
@@ -1,0 +1,2 @@
+"""Empty module for python import traversal."""
+

--- a/integration_tests/test_staticsite/fixtures/runway-basic-site.yml
+++ b/integration_tests/test_staticsite/fixtures/runway-basic-site.yml
@@ -1,0 +1,12 @@
+deployments:
+  - modules:
+    - path: basic-site
+      class_path: runway.module.staticsite.StaticSite
+      environments:
+        dev:
+          namespace: basic-site-dev
+          staticsite_cf_disable: true
+      options:
+        build_output: build
+    regions:
+      - us-east-1

--- a/integration_tests/test_staticsite/test_staticsite.py
+++ b/integration_tests/test_staticsite/test_staticsite.py
@@ -1,4 +1,4 @@
-"""Tests for the CDK module."""
+"""Tests for the StaticSite module."""
 import os
 import glob
 
@@ -10,7 +10,7 @@ from integration_tests.util import (copy_file, copy_dir, import_tests,
 
 
 class StaticSite(IntegrationTest):
-    """Test CDK based module scenarios"""
+    """Test StaticSite based module scenarios"""
     base_dir = os.path.abspath(os.path.dirname(__file__))
     fixtures_dir = os.path.join(base_dir, 'fixtures')
     tests_dir = os.path.join(base_dir, 'tests')

--- a/integration_tests/test_staticsite/test_staticsite.py
+++ b/integration_tests/test_staticsite/test_staticsite.py
@@ -1,0 +1,73 @@
+"""Tests for the CDK module."""
+import os
+import glob
+
+from send2trash import send2trash
+
+from integration_tests.integration_test import IntegrationTest
+from integration_tests.util import (copy_file, copy_dir, import_tests,
+                                    execute_tests)
+
+
+class StaticSite(IntegrationTest):
+    """Test CDK based module scenarios"""
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    fixtures_dir = os.path.join(base_dir, 'fixtures')
+    tests_dir = os.path.join(base_dir, 'tests')
+
+    staticsite_test_dir = os.path.join(base_dir, 'staticsite_test')
+
+    def copy_fixture(self, name='basic-site'):
+        """Copy fixture files for test"""
+        copy_dir(
+            os.path.join(self.fixtures_dir, name),
+            os.path.join(self.staticsite_test_dir, name)
+        )
+
+    def copy_runway(self, template):
+        """Copy runway template to proper directory."""
+        template_file = os.path.join(self.fixtures_dir, 'runway-{}.yml'.format(template))
+        copy_file(template_file, os.path.join(self.staticsite_test_dir, 'runway.yml'))
+
+    def run(self):
+        """Find all tests and run them."""
+        import_tests(self.logger, self.tests_dir, 'test_*')
+        tests = [test(self.logger) for test in StaticSite.__subclasses__()]
+        if not tests:
+            raise Exception('No tests were found.')
+        self.logger.debug('FOUND TESTS: %s', tests)
+        self.set_environment('dev')
+        self.set_env_var('PIPENV_VENV_IN_PROJECT', '1')
+        err_count = execute_tests(tests, self.logger)
+        assert err_count == 0  # assert that all subtests were successful
+        return err_count
+
+    def clean(self):
+        """Clean up StaticSite module directory."""
+        file_types = ('*.yaml', '*.yml')
+        templates = []
+        for file_type in file_types:
+            templates.extend(glob.glob(os.path.join(self.staticsite_test_dir, file_type)))
+        for template in templates:
+            if os.path.isfile(template):
+                self.logger.debug('send2trash: "%s"', template)
+                send2trash(template)
+        folders = ['basic-site']
+        for folder in folders:
+            folder_path = os.path.join(self.staticsite_test_dir, folder)
+            if os.path.isdir(folder_path):
+                self.logger.debug('send2trash: "%s"', folder_path)
+                send2trash(folder_path)
+
+    def delete_venv(self, module_directory):
+        """Delete pipenv venv before running destroy."""
+        folder_path = os.path.join(self.staticsite_test_dir,
+                                   f'{module_directory}/.venv')
+        if os.path.isdir(folder_path):
+            self.logger.debug('send2trash: "%s"', folder_path)
+            send2trash(folder_path)
+
+    def teardown(self):
+        """Teardown resources create during init."""
+        self.unset_env_var('PIPENV_VENV_IN_PROJECT')
+        self.clean()

--- a/integration_tests/test_staticsite/tests/__init__.py
+++ b/integration_tests/test_staticsite/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Empty module for python import traversal."""
+

--- a/integration_tests/test_staticsite/tests/test_basic_site.py
+++ b/integration_tests/test_staticsite/tests/test_basic_site.py
@@ -1,0 +1,33 @@
+"""Test that multiple CDK stacks does not prompt a failure"""
+from runway.util import change_dir
+
+from integration_tests.test_staticsite.test_staticsite import StaticSite
+from integration_tests.util import run_command
+
+
+class TestBasicSite(StaticSite):
+    """Test deploying multiple stacks and ensure all are deployed"""
+
+    TEST_NAME = __name__
+    module_dir = 'basic-site'
+
+    def deploy(self):
+        """Deploy provider."""
+        self.copy_fixture(self.module_dir)
+        self.copy_runway('basic-site')
+        with change_dir(self.staticsite_test_dir):
+            return run_command(['runway', 'deploy'])
+
+    def run(self):
+        """Run tests."""
+        self.clean()
+        self.set_env_var('CI', '1')
+        assert self.deploy() == 0, '{}: Basic Site failed'.format(__name__)
+
+    def teardown(self):
+        self.logger.info('Tearing down: %s', self.TEST_NAME)
+        self.delete_venv(self.module_dir)
+        with change_dir(self.staticsite_test_dir):
+            run_command(['runway', 'destroy'])
+        self.clean()
+        self.unset_env_var('CI')

--- a/integration_tests/test_staticsite/tests/test_basic_site.py
+++ b/integration_tests/test_staticsite/tests/test_basic_site.py
@@ -1,4 +1,4 @@
-"""Test that multiple CDK stacks does not prompt a failure"""
+"""Test deploying a base line static site."""
 from runway.util import change_dir
 
 from integration_tests.test_staticsite.test_staticsite import StaticSite
@@ -6,7 +6,7 @@ from integration_tests.util import run_command
 
 
 class TestBasicSite(StaticSite):
-    """Test deploying multiple stacks and ensure all are deployed"""
+    """Test deploying a base line static site."""
 
     TEST_NAME = __name__
     module_dir = 'basic-site'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     # with the LICENSE file added to its root folder
     # and the following patches applied
     # https://github.com/virtuald/pyhcl/pull/57
-    'pyhcl~=0.3',
+    'pyhcl<0.3.14',
     'pyOpenSSL',  # For embedded hook & associated script usage
     'six',
     'typing;python_version<"3.5"',

--- a/src/runway/__init__.py
+++ b/src/runway/__init__.py
@@ -1,2 +1,2 @@
 """Set package version."""
-__version__ = '1.3.5'
+__version__ = '1.3.6'

--- a/src/runway/__init__.py
+++ b/src/runway/__init__.py
@@ -1,2 +1,2 @@
 """Set package version."""
-__version__ = '1.3.6'
+__version__ = '1.3.7'

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -300,7 +300,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_bucket_policy(self, bucket):
-        """Add a policy to the bucket if CloudFront is disabled. Ensure PublicRead
+        """Add a policy to the bucket if CloudFront is disabled. Ensure PublicRead.
 
         Keyword Args:
             bucket (dict): The bucket resource to place the policy

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -17,7 +17,7 @@ from stacker.context import Context
 
 import troposphere
 from troposphere import (
-    AWSProperty, And, Equals, If, GetAtt, Join, Not, NoValue, Output, Select,
+    AWSProperty, And, Equals, If, Join, Not, NoValue, Output, Select,
     awslambda, cloudfront, iam, s3
 )
 

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -77,7 +77,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
                     'default': '',
                     'description': '(Optional) Domain aliases the '
                                    'distribution'},
-        'CFDisabled': {'type': CFNString,
+        'DisableCloudFront': {'type': CFNString,
                        'default': '',
                        'description': 'Whether to disable CF'},
         'LogBucketName': {'type': CFNString,
@@ -150,11 +150,11 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
         self.template.add_condition(
             'CFEnabled',
-            Not(Equals(variables['CFDisabled'].ref, 'true'))
+            Not(Equals(variables['DisableCloudFront'].ref, 'true'))
         )
         self.template.add_condition(
             'CFDisabled',
-            Equals(variables['CFDisabled'].ref, 'true')
+            Equals(variables['DisableCloudFront'].ref, 'true')
         )
         self.template.add_condition(
             'CFLoggingEnabled',
@@ -170,7 +170,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             'CFEnabledAndDirectoryIndexSpecified',
             And(Not(Equals(variables['RewriteDirectoryIndex'].ref, '')),
                 Not(Equals(variables['RewriteDirectoryIndex'].ref, 'undefined')), # noqa
-                Not(Equals(variables['CFDisabled'].ref, 'true')))
+                Not(Equals(variables['DisableCloudFront'].ref, 'true')))
         )
         self.template.add_condition(
             'WAFNameSpecified',
@@ -340,7 +340,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
 
         """
         variables = self.get_variables()
-        access = s3.PublicRead if (variables['CFDisabled'] == 'true') else s3.Private
+        access = s3.PublicRead if (variables['DisableCloudFront'] == 'true') else s3.Private
         bucket = self.template.add_resource(
             s3.Bucket(
                 'Bucket',

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -333,7 +333,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_bucket(self):
-        """Add the bucket resource along with an output of it's name.
+        """Add the bucket resource along with an output of it's name / website url.
 
         Returns:
             dict: The bucket resource
@@ -368,7 +368,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             Value=bucket.ref()
         ))
         self.template.add_output(Output(
-            'BucketWebsiteUrl',
+            'BucketWebsiteURL',
             Condition="CFDisabled",
             Description='URL of the bucket website',
             Value=GetAtt(bucket, 'WebsiteURL')

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -115,7 +115,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
 
         # Resources
         bucket = self.add_bucket()
-        bucket_policy = self.add_bucket_policy(bucket)
+        bucket_policy = self.add_bucket_policy(bucket) # noqa pylint: disable=unused-variable
         oai = self.add_origin_access_identity()
         allow_access = self.allow_cloudfront_access_on_bucket(bucket, oai)
         rewrite_role = self.add_index_rewrite_role()
@@ -300,6 +300,15 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_bucket_policy(self, bucket):
+        """Add a policy to the bucket if CloudFront is disabled. Ensure PublicRead
+
+        Keyword Args:
+            bucket (dict): The bucket resource to place the policy
+
+        Returns:
+            dict: The Bucket Policy Resource
+
+        """
         return self.template.add_resource(
             s3.BucketPolicy(
                 'BucketPolicy',
@@ -330,7 +339,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             dict: The bucket resource
 
         """
-        variables = self.get_variables();
+        variables = self.get_variables()
         access = s3.PublicRead if (variables['CFDisabled'] == 'true') else s3.Private
         bucket = self.template.add_resource(
             s3.Bucket(

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -78,8 +78,8 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
                     'description': '(Optional) Domain aliases the '
                                    'distribution'},
         'DisableCloudFront': {'type': CFNString,
-                       'default': '',
-                       'description': 'Whether to disable CF'},
+                              'default': '',
+                              'description': 'Whether to disable CF'},
         'LogBucketName': {'type': CFNString,
                           'default': '',
                           'description': 'S3 bucket for CF logs'},
@@ -339,12 +339,10 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             dict: The bucket resource
 
         """
-        variables = self.get_variables()
-        access = s3.PublicRead if (variables['DisableCloudFront'] == 'true') else s3.Private
         bucket = self.template.add_resource(
             s3.Bucket(
                 'Bucket',
-                AccessControl=access,
+                AccessControl=If('CFEnabled', s3.Private, s3.PublicRead),
                 LifecycleConfiguration=s3.LifecycleConfiguration(
                     Rules=[
                         s3.LifecycleRule(

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -134,7 +134,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_template_conditions(self):
-        """Add Template Conditions"""
+        """Add Template Conditions."""
         variables = self.get_variables()
 
         self.template.add_condition(
@@ -174,7 +174,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def get_lambda_associations(self, directory_index_rewrite_version):
-        """Retrieve any lambda associations from the instance variables
+        """Retrieve any lambda associations from the instance variables.
 
         Keyword Args:
             directory_index_rewrite_version (dict): The directory index rewrite lambda version
@@ -205,7 +205,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def get_cloudfront_distribution_options(self, bucket, oai, lambda_function_associations):
-        """Retrieve the options for our CloudFront distribution
+        """Retrieve the options for our CloudFront distribution.
 
         Keyword Args:
             bucket (dict): The bucket resource
@@ -214,6 +214,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
 
         Return:
             dict: The CloudFront Distribution Options
+
         """
         variables = self.get_variables()
         return {
@@ -277,10 +278,11 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         }
 
     def add_origin_access_identity(self):
-        """Add the origin access identity resource to the template
+        """Add the origin access identity resource to the template.
 
         Returns:
             dict: The OAI resource
+
         """
         return self.template.add_resource(
             cloudfront.CloudFrontOriginAccessIdentity(
@@ -293,10 +295,11 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_bucket(self):
-        """Add the bucket resource along with an output of it's name
+        """Add the bucket resource along with an output of it's name.
 
         Returns:
             dict: The bucket resource
+
         """
         bucket = self.template.add_resource(
             s3.Bucket(
@@ -362,12 +365,11 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_index_rewrite_role(self):
-        """Add an index rewrite role to the template
+        """Add an index rewrite role to the template.
 
         Return:
             dict: The index rewrite role
         """
-
         return self.template.add_resource(
             iam.Role(
                 'CFDirectoryIndexRewriteRole',
@@ -391,10 +393,10 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_cloudfront_directory_index_rewrite(self, role):
-        """Add an index CloudFront directory index rewrite lambda function to the template
+        """Add an index CloudFront directory index rewrite lambda function to the template.
 
         Keyword Args:
-            role (dict): The index rewrite role resourcevoodooGQ/runway/pull/3
+            role (dict): The index rewrite role resource
 
         Return:
             dict: The CloudFront directory index rewrite lambda function resource
@@ -437,13 +439,14 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         )
 
     def add_cloudfront_directory_index_rewrite_version(self, directory_index_rewrite):
-        """Add a specific version to the directory index rewrite lambda
+        """Add a specific version to the directory index rewrite lambda.
 
         Keyword Args:
             directory_index_rewrite (dict): The directory index rewrite lambda resource
 
         Return:
             dict: The CloudFront directory index rewrite version
+
         """
         # Generating a unique resource name here for the Lambda version, so it
         # updates automatically if the lambda code changes
@@ -464,8 +467,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             allow_cloudfront_access,
             cloudfront_distribution_options
     ):
-        """Add the CloudFront distribution to the template and output the id
-        and domain name.
+        """Add the CloudFront distribution to the template / output the id and domain name.
 
         Keyword Args:
             allow_cloudfront_access (dict): Allow bucket access resource
@@ -473,6 +475,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
 
         Return:
             dict: The CloudFront Distribution resource
+
         """
         distribution = self.template.add_resource(
             get_cf_distribution_class()(

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -17,7 +17,7 @@ from stacker.context import Context
 
 import troposphere
 from troposphere import (
-    AWSProperty, And, Equals, If, Join, Not, NoValue, Output, Select,
+    AWSProperty, And, Equals, If, GetAtt, Join, Not, NoValue, Output, Select,
     awslambda, cloudfront, iam, s3
 )
 
@@ -366,6 +366,12 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             'BucketName',
             Description='Name of website bucket',
             Value=bucket.ref()
+        ))
+        self.template.add_output(Output(
+            'BucketWebsiteUrl',
+            Condition="CFDisabled",
+            Description='URL of the bucket website',
+            Value=GetAtt(bucket, 'WebsiteURL')
         ))
         return bucket
 

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -367,7 +367,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
             'BucketWebsiteURL',
             Condition="CFDisabled",
             Description='URL of the bucket website',
-            Value=GetAtt(bucket, 'WebsiteURL')
+            Value=bucket.get_att('WebsiteURL')
         ))
         return bucket
 

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -417,7 +417,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
         return self.template.add_resource(
             iam.Role(
                 'CFDirectoryIndexRewriteRole',
-                Condition='DirectoryIndexSpecified',
+                Condition='CFEnabledAndDirectoryIndexSpecified',
                 AssumeRolePolicyDocument=PolicyDocument(
                     Version='2012-10-17',
                     Statement=[

--- a/src/runway/blueprints/staticsite/staticsite.py
+++ b/src/runway/blueprints/staticsite/staticsite.py
@@ -322,9 +322,7 @@ class StaticSite(Blueprint):  # pylint: disable=too-few-public-methods
                             Principal=Principal('*'),
                             Action=[Action('s3', 'getObject')],
                             Resource=[
-                                Join('', ['arn:aws:s3:::',
-                                          bucket.ref(),
-                                          '/*'])
+                                Join('', [bucket.get_att('Arn'), '/*'])
                             ],
                         )
                     ]

--- a/src/runway/commands/modules_command.py
+++ b/src/runway/commands/modules_command.py
@@ -81,7 +81,9 @@ def determine_module_class(path, class_path):  # pylint: disable=too-many-branch
 
     if not class_path:
         # Fallback to autodetection
-        if os.path.isfile(os.path.join(path, 'serverless.yml')):
+        if (os.path.isfile(os.path.join(path, 'serverless.yml'))
+                or os.path.isfile(os.path.join(path, 'serverless.js'))) \
+                and os.path.isfile(os.path.join(path, 'package.json')):
             class_path = 'runway.module.serverless.Serverless'
         elif glob.glob(os.path.join(path, '*.tf')):
             class_path = 'runway.module.terraform.Terraform'

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -59,8 +59,9 @@ def sync(context, provider, **kwargs):
                  "s3://%s/" % bucket_name,
                  '--delete'])
 
-        distribution = get_distribution_data(context, provider, **kwargs)
-        invalidate_distribution(session, **distribution)
+        if kwargs.get('cf_disabled', '') != 'true':
+            distribution = get_distribution_data(context, provider, **kwargs)
+            invalidate_distribution(session, **distribution)
 
         LOGGER.info("staticsite: sync " "complete")
 

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -74,7 +74,7 @@ def update_ssm_hash(context, session):
 
     Keyword Args:
         context (Dict):
-        session (Session): The Stacker Session
+        session (:class:`stacker.context.Context`): context instance
     """
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
         LOGGER.info("staticsite: updating environment SSM parameter %s "
@@ -95,8 +95,9 @@ def update_ssm_hash(context, session):
 def get_distribution_data(context, provider, **kwargs):
     """Retrive information about the distribution
 
-        context (Dict):
-        provider (Dict):
+        context (:class:`stacker.context.Context`): The context instance
+        provider (:class:`stacker.providers.base.BaseProvider`): The provider
+            instance:
     """
     LOGGER.info("Retrieved distribution data")
     return {
@@ -139,7 +140,7 @@ def invalidate_distribution(session, identifier='', path='', domain='', **_):
 def prune_archives(context, session):
     """Prune the archives from the bucket.
 
-        context (Dict):
+        context (:class:`stacker.context.Context`): The context instance
         session (Session): The Stacker session
     """
     LOGGER.info("staticsite: cleaning up old site archives...")

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -95,11 +95,11 @@ def update_ssm_hash(context, session):
 
 
 def get_distribution_data(context, provider, **kwargs):
-    """Retrive information about the distribution.
+    """Retrieve information about the distribution.
 
+    Keyword Args:
         context (:class:`stacker.context.Context`): The context instance
-        provider (:class:`stacker.providers.base.BaseProvider`): The provider
-            instance
+        provider (:class:`stacker.providers.base.BaseProvider`): The provider instance
     """
     LOGGER.info("Retrieved distribution data")
     return {
@@ -118,8 +118,9 @@ def get_distribution_data(context, provider, **kwargs):
 
 
 def invalidate_distribution(session, identifier='', path='', domain='', **_):
-    """Invalidate the current distribution
+    """Invalidate the current distribution.
 
+    Keyword Args:
         session (Session): The current Stacker session
         identifier (string): The distribution id
         path (string): The distribution path
@@ -143,6 +144,7 @@ def invalidate_distribution(session, identifier='', path='', domain='', **_):
 def prune_archives(context, session):
     """Prune the archives from the bucket.
 
+    Keyword Args:
         context (:class:`stacker.context.Context`): The context instance
         session (:class:`stacker.session.Session`): The Stacker session
     """

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -76,7 +76,6 @@ def update_ssm_hash(context, session):
 
     Keyword Args:
         context (:class:`stacker.context.Context`): context instance
-Dict):
         session (:class:`stacker.session.Session`): Stacker session
     """
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
@@ -96,7 +95,7 @@ Dict):
 
 
 def get_distribution_data(context, provider, **kwargs):
-    """Retrive information about the distribution
+    """Retrive information about the distribution.
 
         context (:class:`stacker.context.Context`): The context instance
         provider (:class:`stacker.providers.base.BaseProvider`): The provider
@@ -120,6 +119,7 @@ def get_distribution_data(context, provider, **kwargs):
 
 def invalidate_distribution(session, identifier='', path='', domain='', **_):
     """Invalidate the current distribution
+
         session (Session): The current Stacker session
         identifier (string): The distribution id
         path (string): The distribution path

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -13,7 +13,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_archives_to_prune(archives, hook_data):
-    """Return list of keys to delete."""
+    """Return list of keys to delete.
+
+    Keyword Args:
+        archives (Dict): The full list of file archives
+        hook_data (Dict): Stacker hook data
+
+    """
     files_to_skip = []
 
     for i in ['current_archive_filename', 'old_archive_filename']:
@@ -27,7 +33,13 @@ def get_archives_to_prune(archives, hook_data):
 
 
 def sync(context, provider, **kwargs):
-    """Sync static website to S3 bucket."""
+    """Sync static website to S3 bucket.
+
+    Keyword Args:
+
+        context (Dict):
+        provider (Dict):
+    """
     session = get_session(provider.region)
     bucket_name = OutputLookup.handle(kwargs.get('bucket_output_lookup'),
                                       provider=provider,
@@ -53,13 +65,17 @@ def sync(context, provider, **kwargs):
 
         update_ssm_hash(context, session)
 
-    prune_archives(
-        context=context,
-        session=session
-    )
+    prune_archives(context, session)
     return True
 
+
 def update_ssm_hash(context, session):
+    """Update the SSM hash with the new tracking data.
+
+    Keyword Args:
+        context (Dict):
+        session (Session): The Stacker Session
+    """
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
         LOGGER.info("staticsite: updating environment SSM parameter %s "
                     "with hash %s",
@@ -75,7 +91,13 @@ def update_ssm_hash(context, session):
         )
     return True
 
+
 def get_distribution_data(context, provider, **kwargs):
+    """Retrive information about the distribution
+
+        context (Dict):
+        provider (Dict):
+    """
     LOGGER.info("Retrieved distribution data")
     return {
         'identifier': OutputLookup.handle(
@@ -91,7 +113,14 @@ def get_distribution_data(context, provider, **kwargs):
         'path': kwargs.get('distribution_path', '/*')
     }
 
+
 def invalidate_distribution(session, identifier='', path='', domain='', **_):
+    """Invalidate the current distribution
+        session (Session): The current Stacker session
+        identifier (string): The distribution id
+        path (string): The distribution path
+        domain (string): The distribution domain
+    """
     LOGGER.info("staticsite: Invalidating CF distribution")
     cf_client = session.client('cloudfront')
     cf_client.create_invalidation(
@@ -106,7 +135,13 @@ def invalidate_distribution(session, identifier='', path='', domain='', **_):
     LOGGER.info("staticsite: CF invalidation of %s (domain %s) " "complete", identifier, domain)
     return True
 
-def prune_archives(context=None, session=None):
+
+def prune_archives(context, session):
+    """Prune the archives from the bucket.
+
+        context (Dict):
+        session (Session): The Stacker session
+    """
     LOGGER.info("staticsite: cleaning up old site archives...")
     archives = []
     s3_client = session.client('s3')

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -37,8 +37,9 @@ def sync(context, provider, **kwargs):
 
     Keyword Args:
 
-        context (Dict):
-        provider (Dict):
+        context (:class:`stacker.context.Context`): The context instance
+        provider (:class:`stacker.providers.base.BaseProvider`): The provider
+            instance
     """
     session = get_session(provider.region)
     bucket_name = OutputLookup.handle(kwargs.get('bucket_output_lookup'),
@@ -73,8 +74,9 @@ def update_ssm_hash(context, session):
     """Update the SSM hash with the new tracking data.
 
     Keyword Args:
-        context (Dict):
-        session (:class:`stacker.context.Context`): context instance
+        context (:class:`stacker.context.Context`): context instance
+Dict):
+        session (:class:`stacker.session.Session`): Stacker session
     """
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
         LOGGER.info("staticsite: updating environment SSM parameter %s "
@@ -97,7 +99,7 @@ def get_distribution_data(context, provider, **kwargs):
 
         context (:class:`stacker.context.Context`): The context instance
         provider (:class:`stacker.providers.base.BaseProvider`): The provider
-            instance:
+            instance
     """
     LOGGER.info("Retrieved distribution data")
     return {
@@ -141,7 +143,7 @@ def prune_archives(context, session):
     """Prune the archives from the bucket.
 
         context (:class:`stacker.context.Context`): The context instance
-        session (Session): The Stacker session
+        session (:class:`stacker.session.Session`): The Stacker session
     """
     LOGGER.info("staticsite: cleaning up old site archives...")
     archives = []

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -46,12 +46,12 @@ def sync(context, provider, **kwargs):
                  "s3://%s/" % bucket_name,
                  '--delete'])
 
-        distribution = get_distribution_data(context=context, provider=provider, **kwargs)
-        invalidate_distribution(session=session, **distribution)
+        distribution = get_distribution_data(context, provider, **kwargs)
+        invalidate_distribution(session, **distribution)
 
         LOGGER.info("staticsite: sync " "complete")
 
-        update_ssm_hash(context=context, session=session)
+        update_ssm_hash(context, session)
 
     prune_archives(
         context=context,
@@ -59,7 +59,7 @@ def sync(context, provider, **kwargs):
     )
     return True
 
-def update_ssm_hash(context=None, session=None):
+def update_ssm_hash(context, session):
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
         LOGGER.info("staticsite: updating environment SSM parameter %s "
                     "with hash %s",
@@ -75,7 +75,7 @@ def update_ssm_hash(context=None, session=None):
         )
     return True
 
-def get_distribution_data(context=None, provider=None, **kwargs):
+def get_distribution_data(context, provider, **kwargs):
     LOGGER.info("Retrieved distribution data")
     return {
         'identifier': OutputLookup.handle(
@@ -91,7 +91,7 @@ def get_distribution_data(context=None, provider=None, **kwargs):
         'path': kwargs.get('distribution_path', '/*')
     }
 
-def invalidate_distribution(session=None, identifier='', path='', domain='', **_):
+def invalidate_distribution(session, identifier='', path='', domain='', **_):
     LOGGER.info("staticsite: Invalidating CF distribution")
     cf_client = session.client('cloudfront')
     cf_client.create_invalidation(

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -15,16 +15,18 @@ LOGGER = logging.getLogger(__name__)
 def get_archives_to_prune(archives, hook_data):
     """Return list of keys to delete."""
     files_to_skip = []
+
     for i in ['current_archive_filename', 'old_archive_filename']:
         if hook_data.get(i):
             files_to_skip.append(hook_data[i])
-    archives.sort(key=itemgetter('LastModified'),
-                  reverse=False)  # sort from oldest to newest
+
+    archives.sort(key=itemgetter('LastModified'), reverse=False)  # sort from oldest to newest
+
     # Drop all but last 15 files
     return [i['Key'] for i in archives[:-15] if i['Key'] not in files_to_skip]
 
 
-def sync(context, provider, **kwargs):  # pylint: disable=too-many-locals
+def sync(context, provider, **kwargs):
     """Sync static website to S3 bucket."""
     session = get_session(provider.region)
     bucket_name = OutputLookup.handle(kwargs.get('bucket_output_lookup'),
@@ -35,18 +37,6 @@ def sync(context, provider, **kwargs):  # pylint: disable=too-many-locals
         LOGGER.info('staticsite: skipping upload; latest version already '
                     'deployed')
     else:
-        distribution_id = OutputLookup.handle(
-            kwargs.get('distributionid_output_lookup'),
-            provider=provider,
-            context=context
-        )
-        distribution_domain = OutputLookup.handle(
-            kwargs.get('distributiondomain_output_lookup'),
-            provider=provider,
-            context=context
-        )
-        distribution_path = kwargs.get('distribution_path', '/*')
-
         # Using the awscli for s3 syncing is incredibly suboptimal, but on
         # balance it's probably the most stable/efficient option for syncing
         # the files until https://github.com/boto/boto3/issues/358 is resolved
@@ -56,33 +46,67 @@ def sync(context, provider, **kwargs):  # pylint: disable=too-many-locals
                  "s3://%s/" % bucket_name,
                  '--delete'])
 
-        cf_client = session.client('cloudfront')
-        cf_client.create_invalidation(
-            DistributionId=distribution_id,
-            InvalidationBatch={
-                'Paths': {
-                    'Quantity': 1,
-                    'Items': [distribution_path]},
-                'CallerReference': str(time.time())}
-        )
-        LOGGER.info("staticsite: sync & CF invalidation of %s (domain %s) "
-                    "complete",
-                    distribution_id,
-                    distribution_domain)
+        distribution = get_distribution_data(context=context, provider=provider, **kwargs)
+        invalidate_distribution(session=session, **distribution)
 
-        if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
-            LOGGER.info("staticsite: updating environment SSM parameter %s "
-                        "with hash %s",
-                        context.hook_data['staticsite']['hash_tracking_parameter'],  # noqa
-                        context.hook_data['staticsite']['hash'])
-            ssm_client = session.client('ssm')
-            ssm_client.put_parameter(
-                Name=context.hook_data['staticsite']['hash_tracking_parameter'],  # noqa
-                Description='Hash of currently deployed static website source',
-                Value=context.hook_data['staticsite']['hash'],
-                Type='String',
-                Overwrite=True
-            )
+        LOGGER.info("staticsite: sync " "complete")
+
+        update_ssm_hash(context=context, session=session)
+
+    prune_archives(
+        context=context,
+        session=session
+    )
+    return True
+
+def update_ssm_hash(context=None, session=None):
+    if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
+        LOGGER.info("staticsite: updating environment SSM parameter %s "
+                    "with hash %s",
+                    context.hook_data['staticsite']['hash_tracking_parameter'],  # noqa
+                    context.hook_data['staticsite']['hash'])
+        ssm_client = session.client('ssm')
+        ssm_client.put_parameter(
+            Name=context.hook_data['staticsite']['hash_tracking_parameter'],  # noqa
+            Description='Hash of currently deployed static website source',
+            Value=context.hook_data['staticsite']['hash'],
+            Type='String',
+            Overwrite=True
+        )
+    return True
+
+def get_distribution_data(context=None, provider=None, **kwargs):
+    LOGGER.info("Retrieved distribution data")
+    return {
+        'identifier': OutputLookup.handle(
+            kwargs.get('distributionid_output_lookup'),
+            provider=provider,
+            context=context
+        ),
+        'domain': OutputLookup.handle(
+            kwargs.get('distributiondomain_output_lookup'),
+            provider=provider,
+            context=context
+        ),
+        'path': kwargs.get('distribution_path', '/*')
+    }
+
+def invalidate_distribution(session=None, identifier='', path='', domain='', **_):
+    LOGGER.info("staticsite: Invalidating CF distribution")
+    cf_client = session.client('cloudfront')
+    cf_client.create_invalidation(
+        DistributionId=identifier,
+        InvalidationBatch={
+            'Paths': {
+                'Quantity': 1,
+                'Items': [path]},
+            'CallerReference': str(time.time())}
+    )
+
+    LOGGER.info("staticsite: CF invalidation of %s (domain %s) " "complete", identifier, domain)
+    return True
+
+def prune_archives(context=None, session=None):
     LOGGER.info("staticsite: cleaning up old site archives...")
     archives = []
     s3_client = session.client('s3')
@@ -91,12 +115,14 @@ def sync(context, provider, **kwargs):  # pylint: disable=too-many-locals
         Bucket=context.hook_data['staticsite']['artifact_bucket_name'],
         Prefix=context.hook_data['staticsite']['artifact_key_prefix']
     )
+
     for page in response_iterator:
         archives.extend(page.get('Contents', []))
     archives_to_prune = get_archives_to_prune(
         archives,
         context.hook_data['staticsite']
     )
+
     # Iterate in chunks of 1000 to match delete_objects limit
     for objects in [archives_to_prune[i:i + 1000]
                     for i in range(0, len(archives_to_prune), 1000)]:

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -79,6 +79,7 @@ class StaticSite(RunwayModule):
         site_stack_variables = {
             'AcmCertificateArn': '${default staticsite_acmcert_arn::undefined}',
             'Aliases': '${default staticsite_aliases::undefined}',
+            'CFDisabled': '${default staticsite_cf_disable::undefined}',
             'RewriteDirectoryIndex': '${default staticsite_rewrite_directory_index::undefined}',  # noqa pylint: disable=line-too-long
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }
@@ -90,6 +91,9 @@ class StaticSite(RunwayModule):
 
         if env.get('staticsite_enable_cf_logging', True):
             site_stack_variables['LogBucketName'] = "${rxref %s-dependencies::AWSLogBucketName}" % name  # noqa pylint: disable=line-too-long
+
+        if env.get('staticsite_cf_disable', False):
+            site_stack_variables['CFDisabled'] = "true"
 
         # If lambda_function_associations or custom_error_responses defined,
         # add to stack config
@@ -119,6 +123,7 @@ class StaticSite(RunwayModule):
                       'required': True,
                       'args': {
                           'bucket_output_lookup': '%s::BucketName' % name,
+                          'cf_disabled': '%s' % site_stack_variables['CFDisabled'],
                           'distributionid_output_lookup': '%s::CFDistributionId' % name,  # noqa
                           'distributiondomain_output_lookup': '%s::CFDistributionDomainName' % name}}  # noqa pylint: disable=line-too-long
                  ],

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -78,7 +78,7 @@ class StaticSite(RunwayModule):
         site_stack_variables = {
             'AcmCertificateArn': '${default staticsite_acmcert_arn::undefined}',
             'Aliases': '${default staticsite_aliases::undefined}',
-            'CFDisabled': '${default staticsite_cf_disable::undefined}',
+            'DisableCloudFront': '${default staticsite_cf_disable::undefined}',
             'RewriteDirectoryIndex': '${default staticsite_rewrite_directory_index::undefined}',  # noqa pylint: disable=line-too-long
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -77,13 +77,13 @@ class StaticSite(RunwayModule):
                 default_flow_style=False
             )
         site_stack_variables = {
+            'AcmCertificateArn': '${default staticsite_acmcert_arn::undefined}',
             'Aliases': '${default staticsite_aliases::undefined}',
             'RewriteDirectoryIndex': '${default staticsite_rewrite_directory_index::undefined}',  # noqa pylint: disable=line-too-long
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }
 
         env = self.options.get('environments', {}).get(self.context.env_name, {})
-        site_stack_variables['AcmCertificateArn'] = '${default staticsite_acmcert_arn::undefined}'
 
         if env.get('staticsite_acmcert_ssm_param'):
             site_stack_variables['AcmCertificateArn'] = '${ssmstore ${staticsite_acmcert_ssm_param}}'  # noqa pylint: disable=line-too-long

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -162,12 +162,13 @@ class StaticSite(RunwayModule):
 
     def deploy(self):
         """Create website CFN module and run stacker build."""
-        if self.options.get('environments', {}).get(self.context.env_name):
-            if self.options.get('staticsite_cf_disable', False) is False:
-                msg = ("PLEASE NOTE: Initial creation or updates to distribution settings "
+        env = self.options.get('environments', {}).get(self.context.env_name)
+        if env:
+            if env.get('staticsite_cf_disable', False) is False:
+                msg = ("Please Note: Initial creation or updates to distribution settings "
                        "(e.g. url rewrites) will take quite a while (up to an hour). "
                        "Unless you receive an error your deployment is still running.")
-                LOGGER.info(msg)
+                LOGGER.info(msg.upper())
 
             self.setup_website_module(command='deploy')
         else:

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -163,6 +163,12 @@ class StaticSite(RunwayModule):
     def deploy(self):
         """Create website CFN module and run stacker build."""
         if self.options.get('environments', {}).get(self.context.env_name):
+            if self.options.get('staticsite_cf_disable', False) is False:
+                msg = ("PLEASE NOTE: Initial creation or updates to distribution settings "
+                       "(e.g. url rewrites) will take quite a while (up to an hour). "
+                       "Unless you receive an error your deployment is still running.")
+                LOGGER.info(msg)
+
             self.setup_website_module(command='deploy')
         else:
             LOGGER.info("Skipping staticsite deploy of %s; no environment "

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -82,7 +82,7 @@ class StaticSite(RunwayModule):
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }
 
-        env = self.options.get('environments', ()).get(self.context.env_name, {})
+        env = self.options.get('environments', {}).get(self.context.env_name, {})
         site_stack_variables['AcmCertificateArn'] = '${default staticsite_acmcert_arn::undefined}'
 
         if env.get('staticsite_acmcert_ssm_param'):

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -28,9 +28,7 @@ class StaticSite(RunwayModule):
     def setup_website_module(self, command):
         """Create stacker configuration for website module."""
 
-        name = self.options.get('path')
-        if self.options.get('name'):
-            name = self.options.get('name')
+        name = self.options.get('name', self.options.get('path'))
 
         ensure_valid_environment_config(
             name,

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -27,7 +27,6 @@ class StaticSite(RunwayModule):
 
     def setup_website_module(self, command):
         """Create stacker configuration for website module."""
-
         name = self.options.get('name', self.options.get('path'))
 
         ensure_valid_environment_config(

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -122,6 +122,7 @@ class StaticSite(RunwayModule):
                       'required': True,
                       'args': {
                           'bucket_output_lookup': '%s::BucketName' % name,
+                          'website_url': '%s::BucketWebsiteURL' % name,
                           'cf_disabled': '%s' % site_stack_variables['CFDisabled'],
                           'distributionid_output_lookup': '%s::CFDistributionId' % name,  # noqa
                           'distributiondomain_output_lookup': '%s::CFDistributionDomainName' % name}}  # noqa pylint: disable=line-too-long

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -92,7 +92,7 @@ class StaticSite(RunwayModule):
             site_stack_variables['LogBucketName'] = "${rxref %s-dependencies::AWSLogBucketName}" % name  # noqa pylint: disable=line-too-long
 
         if env.get('staticsite_cf_disable', False):
-            site_stack_variables['CFDisabled'] = "true"
+            site_stack_variables['DisableCloudFront'] = "true"
 
         # If lambda_function_associations or custom_error_responses defined,
         # add to stack config
@@ -123,7 +123,7 @@ class StaticSite(RunwayModule):
                       'args': {
                           'bucket_output_lookup': '%s::BucketName' % name,
                           'website_url': '%s::BucketWebsiteURL' % name,
-                          'cf_disabled': '%s' % site_stack_variables['CFDisabled'],
+                          'cf_disabled': '%s' % site_stack_variables['DisableCloudFront'],
                           'distributionid_output_lookup': '%s::CFDistributionId' % name,  # noqa
                           'distributiondomain_output_lookup': '%s::CFDistributionDomainName' % name}}  # noqa pylint: disable=line-too-long
                  ],

--- a/src/runway/templates/sls-tsc/package.json
+++ b/src/runway/templates/sls-tsc/package.json
@@ -30,7 +30,7 @@
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.15.6",
     "typescript": "^3.3.3333",
     "webpack": "^4.29.6"
   },

--- a/src/runway/templates/sls-tsc/serverless.yml
+++ b/src/runway/templates/sls-tsc/serverless.yml
@@ -7,6 +7,13 @@ provider:
   name: aws
   runtime: nodejs10.x
 
+# After adding a few functions and associated dependencies, individual function
+# packages can be created to avoid a single massive zip file.
+# This comes at the cost of potential memory issues at build time:
+# https://github.com/serverless-heaven/serverless-webpack/issues/299
+# package:
+#   individually: true
+
 custom:
   webpack:
     excludeFiles:

--- a/src/runway/templates/sls-tsc/src/helloWorld.ts
+++ b/src/runway/templates/sls-tsc/src/helloWorld.ts
@@ -1,8 +1,9 @@
 /**
  * hello-world API
+ *
+ * @packageDocumentation
  */
 
-/** imports (delete comment after https://github.com/TypeStrong/typedoc/issues/603 resolution) */
 import {
   APIGatewayProxyEvent,
   APIGatewayProxyHandler,


### PR DESCRIPTION
This PR presents some general cleanup of the StaticSite module as well as making the CloudFront portion of the deployment optional for development purposes. 

An integration test has been provided to verify the StaticSite module works as intended, however, due to the amount of time that would need to be taken to launch CloudFront that has been disabled for the test.

Additional documentation provided outlining the length of time that may come from running CloudFront with the build.