### PR TITLE
Optional CloudFront on StaticSite deploy

### DIFF
--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -39,7 +39,8 @@ A start-to-finish example walkthrough is available
 in the :ref:`Conduit quickstart<qs-conduit>`.
 
 Please note that the CloudFront distribution will take a significant amount
-of time to spin up on initial deploy (10 to 25 minutes is not abnormal). If
+of time to spin up on initial deploy (10 to 25 minutes is not abnormal). Incorporating
+CloudFront with a static site is a common best practice, however, if
 you are working on a development project it may benefit you to add the
 `staticsite_cf_disable` environment parameter to `true`.
 

--- a/docs/source/module_configuration/staticsite.rst
+++ b/docs/source/module_configuration/staticsite.rst
@@ -4,8 +4,8 @@ Static Site
 ===========
 
 This module type performs idempotent deployments of static websites. It
-combines CloudFormation stacks (for S3 buckets & CloudFront Distribution) with
-additional logic to build & sync the sites.
+combines CloudFormation stacks (for S3 buckets & CloudFront Distribution)
+with additional logic to build & sync the sites.
 
 It can be used with a configuration like the following::
 
@@ -37,6 +37,11 @@ be displayed on stack creation/updates.
 
 A start-to-finish example walkthrough is available
 in the :ref:`Conduit quickstart<qs-conduit>`.
+
+Please note that the CloudFront distribution will take a significant amount
+of time to spin up on initial deploy (10 to 25 minutes is not abnormal). If
+you are working on a development project it may benefit you to add the
+`staticsite_cf_disable` environment parameter to `true`.
 
 
 .. _staticsite-config-options:
@@ -82,6 +87,9 @@ Most of these options are not required, but are listed here for reference::
                   - ErrorCode: 404
                     ResponseCode: 200
                     ResponsePagePath: /index.html
+
+                # Exclude the CloudFront distribution from overall deployment
+                statisite_cf_disable: true
             options:
               pre_build_steps:  # commands to run before generating hash of files
                 - command: npm ci

--- a/integration_tests/test_staticsite/__init__.py
+++ b/integration_tests/test_staticsite/__init__.py
@@ -1,0 +1,2 @@
+"""Empty module for python import traversal."""
+

--- a/integration_tests/test_staticsite/fixtures/runway-basic-site.yml
+++ b/integration_tests/test_staticsite/fixtures/runway-basic-site.yml
@@ -1,0 +1,12 @@
+deployments:
+  - modules:
+    - path: basic-site
+      class_path: runway.module.staticsite.StaticSite
+      environments:
+        dev:
+          namespace: basic-site-dev
+          staticsite_cf_disable: true
+      options:
+        build_output: build
+    regions:
+      - us-east-1

--- a/integration_tests/test_staticsite/test_staticsite.py
+++ b/integration_tests/test_staticsite/test_staticsite.py
@@ -1,0 +1,73 @@
+"""Tests for the CDK module."""
+import os
+import glob
+
+from send2trash import send2trash
+
+from integration_tests.integration_test import IntegrationTest
+from integration_tests.util import (copy_file, copy_dir, import_tests,
+                                    execute_tests)
+
+
+class StaticSite(IntegrationTest):
+    """Test CDK based module scenarios"""
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    fixtures_dir = os.path.join(base_dir, 'fixtures')
+    tests_dir = os.path.join(base_dir, 'tests')
+
+    staticsite_test_dir = os.path.join(base_dir, 'staticsite_test')
+
+    def copy_fixture(self, name='basic-site'):
+        """Copy fixture files for test"""
+        copy_dir(
+            os.path.join(self.fixtures_dir, name),
+            os.path.join(self.staticsite_test_dir, name)
+        )
+
+    def copy_runway(self, template):
+        """Copy runway template to proper directory."""
+        template_file = os.path.join(self.fixtures_dir, 'runway-{}.yml'.format(template))
+        copy_file(template_file, os.path.join(self.staticsite_test_dir, 'runway.yml'))
+
+    def run(self):
+        """Find all tests and run them."""
+        import_tests(self.logger, self.tests_dir, 'test_*')
+        tests = [test(self.logger) for test in StaticSite.__subclasses__()]
+        if not tests:
+            raise Exception('No tests were found.')
+        self.logger.debug('FOUND TESTS: %s', tests)
+        self.set_environment('dev')
+        self.set_env_var('PIPENV_VENV_IN_PROJECT', '1')
+        err_count = execute_tests(tests, self.logger)
+        assert err_count == 0  # assert that all subtests were successful
+        return err_count
+
+    def clean(self):
+        """Clean up StaticSite module directory."""
+        file_types = ('*.yaml', '*.yml')
+        templates = []
+        for file_type in file_types:
+            templates.extend(glob.glob(os.path.join(self.staticsite_test_dir, file_type)))
+        for template in templates:
+            if os.path.isfile(template):
+                self.logger.debug('send2trash: "%s"', template)
+                send2trash(template)
+        folders = ['basic-site']
+        for folder in folders:
+            folder_path = os.path.join(self.staticsite_test_dir, folder)
+            if os.path.isdir(folder_path):
+                self.logger.debug('send2trash: "%s"', folder_path)
+                send2trash(folder_path)
+
+    def delete_venv(self, module_directory):
+        """Delete pipenv venv before running destroy."""
+        folder_path = os.path.join(self.staticsite_test_dir,
+                                   f'{module_directory}/.venv')
+        if os.path.isdir(folder_path):
+            self.logger.debug('send2trash: "%s"', folder_path)
+            send2trash(folder_path)
+
+    def teardown(self):
+        """Teardown resources create during init."""
+        self.unset_env_var('PIPENV_VENV_IN_PROJECT')
+        self.clean()

--- a/integration_tests/test_staticsite/tests/__init__.py
+++ b/integration_tests/test_staticsite/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Empty module for python import traversal."""
+

--- a/integration_tests/test_staticsite/tests/test_basic_site.py
+++ b/integration_tests/test_staticsite/tests/test_basic_site.py
@@ -1,0 +1,33 @@
+"""Test that multiple CDK stacks does not prompt a failure"""
+from runway.util import change_dir
+
+from integration_tests.test_staticsite.test_staticsite import StaticSite
+from integration_tests.util import run_command
+
+
+class TestBasicSite(StaticSite):
+    """Test deploying multiple stacks and ensure all are deployed"""
+
+    TEST_NAME = __name__
+    module_dir = 'basic-site'
+
+    def deploy(self):
+        """Deploy provider."""
+        self.copy_fixture(self.module_dir)
+        self.copy_runway('basic-site')
+        with change_dir(self.staticsite_test_dir):
+            return run_command(['runway', 'deploy'])
+
+    def run(self):
+        """Run tests."""
+        self.clean()
+        self.set_env_var('CI', '1')
+        assert self.deploy() == 0, '{}: Basic Site failed'.format(__name__)
+
+    def teardown(self):
+        self.logger.info('Tearing down: %s', self.TEST_NAME)
+        self.delete_venv(self.module_dir)
+        with change_dir(self.staticsite_test_dir):
+            run_command(['runway', 'destroy'])
+        self.clean()
+        self.unset_env_var('CI')

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     # with the LICENSE file added to its root folder
     # and the following patches applied
     # https://github.com/virtuald/pyhcl/pull/57
-    'pyhcl~=0.3',
+    'pyhcl<0.3.14',
     'pyOpenSSL',  # For embedded hook & associated script usage
     'six',
     'typing;python_version<"3.5"',

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -59,8 +59,9 @@ def sync(context, provider, **kwargs):
                  "s3://%s/" % bucket_name,
                  '--delete'])
 
-        distribution = get_distribution_data(context, provider, **kwargs)
-        invalidate_distribution(session, **distribution)
+        if kwargs.get('cf_disabled', '') != 'true':
+            distribution = get_distribution_data(context, provider, **kwargs)
+            invalidate_distribution(session, **distribution)
 
         LOGGER.info("staticsite: sync " "complete")
 

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -74,7 +74,7 @@ def update_ssm_hash(context, session):
 
     Keyword Args:
         context (Dict):
-        session (Session): The Stacker Session
+        session (:class:`stacker.context.Context`): context instance
     """
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
         LOGGER.info("staticsite: updating environment SSM parameter %s "
@@ -95,8 +95,9 @@ def update_ssm_hash(context, session):
 def get_distribution_data(context, provider, **kwargs):
     """Retrive information about the distribution
 
-        context (Dict):
-        provider (Dict):
+        context (:class:`stacker.context.Context`): The context instance
+        provider (:class:`stacker.providers.base.BaseProvider`): The provider
+            instance:
     """
     LOGGER.info("Retrieved distribution data")
     return {
@@ -139,7 +140,7 @@ def invalidate_distribution(session, identifier='', path='', domain='', **_):
 def prune_archives(context, session):
     """Prune the archives from the bucket.
 
-        context (Dict):
+        context (:class:`stacker.context.Context`): The context instance
         session (Session): The Stacker session
     """
     LOGGER.info("staticsite: cleaning up old site archives...")

--- a/src/runway/hooks/staticsite/upload_staticsite.py
+++ b/src/runway/hooks/staticsite/upload_staticsite.py
@@ -37,8 +37,9 @@ def sync(context, provider, **kwargs):
 
     Keyword Args:
 
-        context (Dict):
-        provider (Dict):
+        context (:class:`stacker.context.Context`): The context instance
+        provider (:class:`stacker.providers.base.BaseProvider`): The provider
+            instance
     """
     session = get_session(provider.region)
     bucket_name = OutputLookup.handle(kwargs.get('bucket_output_lookup'),
@@ -73,8 +74,9 @@ def update_ssm_hash(context, session):
     """Update the SSM hash with the new tracking data.
 
     Keyword Args:
-        context (Dict):
-        session (:class:`stacker.context.Context`): context instance
+        context (:class:`stacker.context.Context`): context instance
+Dict):
+        session (:class:`stacker.session.Session`): Stacker session
     """
     if not context.hook_data['staticsite'].get('hash_tracking_disabled'):
         LOGGER.info("staticsite: updating environment SSM parameter %s "
@@ -97,7 +99,7 @@ def get_distribution_data(context, provider, **kwargs):
 
         context (:class:`stacker.context.Context`): The context instance
         provider (:class:`stacker.providers.base.BaseProvider`): The provider
-            instance:
+            instance
     """
     LOGGER.info("Retrieved distribution data")
     return {
@@ -141,7 +143,7 @@ def prune_archives(context, session):
     """Prune the archives from the bucket.
 
         context (:class:`stacker.context.Context`): The context instance
-        session (Session): The Stacker session
+        session (:class:`stacker.session.Session`): The Stacker session
     """
     LOGGER.info("staticsite: cleaning up old site archives...")
     archives = []

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -79,6 +79,7 @@ class StaticSite(RunwayModule):
         site_stack_variables = {
             'AcmCertificateArn': '${default staticsite_acmcert_arn::undefined}',
             'Aliases': '${default staticsite_aliases::undefined}',
+            'CFDisabled': '${default staticsite_cf_disable::undefined}',
             'RewriteDirectoryIndex': '${default staticsite_rewrite_directory_index::undefined}',  # noqa pylint: disable=line-too-long
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }
@@ -90,6 +91,9 @@ class StaticSite(RunwayModule):
 
         if env.get('staticsite_enable_cf_logging', True):
             site_stack_variables['LogBucketName'] = "${rxref %s-dependencies::AWSLogBucketName}" % name  # noqa pylint: disable=line-too-long
+
+        if env.get('staticsite_cf_disable', False):
+            site_stack_variables['CFDisabled'] = "true"
 
         # If lambda_function_associations or custom_error_responses defined,
         # add to stack config
@@ -119,6 +123,7 @@ class StaticSite(RunwayModule):
                       'required': True,
                       'args': {
                           'bucket_output_lookup': '%s::BucketName' % name,
+                          'cf_disabled': '%s' % site_stack_variables['CFDisabled'],
                           'distributionid_output_lookup': '%s::CFDistributionId' % name,  # noqa
                           'distributiondomain_output_lookup': '%s::CFDistributionDomainName' % name}}  # noqa pylint: disable=line-too-long
                  ],

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -77,13 +77,13 @@ class StaticSite(RunwayModule):
                 default_flow_style=False
             )
         site_stack_variables = {
+            'AcmCertificateArn': '${default staticsite_acmcert_arn::undefined}',
             'Aliases': '${default staticsite_aliases::undefined}',
             'RewriteDirectoryIndex': '${default staticsite_rewrite_directory_index::undefined}',  # noqa pylint: disable=line-too-long
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }
 
         env = self.options.get('environments', {}).get(self.context.env_name, {})
-        site_stack_variables['AcmCertificateArn'] = '${default staticsite_acmcert_arn::undefined}'
 
         if env.get('staticsite_acmcert_ssm_param'):
             site_stack_variables['AcmCertificateArn'] = '${ssmstore ${staticsite_acmcert_ssm_param}}'  # noqa pylint: disable=line-too-long

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -82,7 +82,7 @@ class StaticSite(RunwayModule):
             'WAFWebACL': '${default staticsite_web_acl::undefined}'
         }
 
-        env = self.options.get('environments', ()).get(self.context.env_name, {})
+        env = self.options.get('environments', {}).get(self.context.env_name, {})
         site_stack_variables['AcmCertificateArn'] = '${default staticsite_acmcert_arn::undefined}'
 
         if env.get('staticsite_acmcert_ssm_param'):

--- a/src/runway/module/staticsite.py
+++ b/src/runway/module/staticsite.py
@@ -28,9 +28,7 @@ class StaticSite(RunwayModule):
     def setup_website_module(self, command):
         """Create stacker configuration for website module."""
 
-        name = self.options.get('path')
-        if self.options.get('name'):
-            name = self.options.get('name')
+        name = self.options.get('name', self.options.get('path'))
 
         ensure_valid_environment_config(
             name,


### PR DESCRIPTION
Dependent on merge of https://github.com/voodooGQ/runway/pull/3

This PR adds the ability to make CloudFront optional on StaticSite deploys. The thought process is that in development type environments you may not want CloudFront functionality.

A test has been added to verify basic site deployment functionality. CloudFront is set to disabled to avoid lengthy test runs. 

Documentation has been updated on the StaticSite page to inform of the increased time required to deploy with CloudFront and how to set it to optional during development practices.